### PR TITLE
Fix bug with a tag containing only the text 0

### DIFF
--- a/src/Jade/Node.php
+++ b/src/Jade/Node.php
@@ -28,7 +28,7 @@ class Node {
 		}
 		if ($type == 'text') {
 			$string = func_get_arg(1);
-			if ( !empty($string) ) {
+			if ( isset($string) && $string !== "") {
 				$this->lines = explode("\n", $string);
 			}
 		}

--- a/tests/RegressionTest.php
+++ b/tests/RegressionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once 'src/Jade/Node.php';
+require_once 'src/Jade/Dumper.php';
+require_once 'src/Jade/Lexer.php';
+require_once 'src/Jade/Parser.php';
+require_once 'src/Jade/Jade.php';
+
+use Jade\Jade;
+use Jade\Dumper;
+use Jade\Parser;
+use Jade\Lexer;
+
+class RegressionTest extends \PHPUnit_Framework_TestCase {
+
+    protected $jade;
+
+    public function __construct() {
+        $parser = new Parser(new Lexer());
+        $dumper = new Dumper();
+
+        $this->jade = new Jade($parser, $dumper);
+    }
+
+    protected function parse($value) {
+        return $this->jade->render($value);
+    }
+
+    public function testLiteralZero() {
+        $this->assertEquals('<p>0</p>' , $this->parse('p 0'));
+    }
+}


### PR DESCRIPTION
This fixes a bug and adds a test for the case that a tag contains only a literal 0 as its contents.
